### PR TITLE
Move classes to their own packages

### DIFF
--- a/src/main/kotlin/Attributes.kt
+++ b/src/main/kotlin/Attributes.kt
@@ -2,7 +2,7 @@ package cloud.drakon.ktlodestone
 
 import cloud.drakon.ktlodestone.exception.CharacterNotFoundException
 import cloud.drakon.ktlodestone.exception.LodestoneException
-import cloud.drakon.ktlodestone.profile.ProfileAttributes
+import cloud.drakon.ktlodestone.profile.attributes.ProfileAttributes
 import io.ktor.client.call.body
 import io.ktor.client.request.get
 import kotlinx.coroutines.async

--- a/src/main/kotlin/Character.kt
+++ b/src/main/kotlin/Character.kt
@@ -2,11 +2,11 @@ package cloud.drakon.ktlodestone
 
 import cloud.drakon.ktlodestone.exception.CharacterNotFoundException
 import cloud.drakon.ktlodestone.exception.LodestoneException
-import cloud.drakon.ktlodestone.profile.ActiveClassJob
-import cloud.drakon.ktlodestone.profile.GrandCompany
-import cloud.drakon.ktlodestone.profile.Guardian
-import cloud.drakon.ktlodestone.profile.ProfileCharacter
-import cloud.drakon.ktlodestone.profile.Town
+import cloud.drakon.ktlodestone.profile.character.ActiveClassJob
+import cloud.drakon.ktlodestone.profile.character.GrandCompany
+import cloud.drakon.ktlodestone.profile.character.Guardian
+import cloud.drakon.ktlodestone.profile.character.ProfileCharacter
+import cloud.drakon.ktlodestone.profile.character.Town
 import cloud.drakon.ktlodestone.profile.guild.Guild
 import cloud.drakon.ktlodestone.profile.guild.GuildType
 import cloud.drakon.ktlodestone.profile.guild.IconLayers

--- a/src/main/kotlin/Character.kt
+++ b/src/main/kotlin/Character.kt
@@ -5,11 +5,11 @@ import cloud.drakon.ktlodestone.exception.LodestoneException
 import cloud.drakon.ktlodestone.profile.ActiveClassJob
 import cloud.drakon.ktlodestone.profile.GrandCompany
 import cloud.drakon.ktlodestone.profile.Guardian
-import cloud.drakon.ktlodestone.profile.Guild
-import cloud.drakon.ktlodestone.profile.GuildType
-import cloud.drakon.ktlodestone.profile.IconLayers
 import cloud.drakon.ktlodestone.profile.ProfileCharacter
 import cloud.drakon.ktlodestone.profile.Town
+import cloud.drakon.ktlodestone.profile.guild.Guild
+import cloud.drakon.ktlodestone.profile.guild.GuildType
+import cloud.drakon.ktlodestone.profile.guild.IconLayers
 import io.ktor.client.call.body
 import io.ktor.client.request.get
 import kotlinx.coroutines.async

--- a/src/main/kotlin/ClassJob.kt
+++ b/src/main/kotlin/ClassJob.kt
@@ -2,9 +2,9 @@ package cloud.drakon.ktlodestone
 
 import cloud.drakon.ktlodestone.exception.CharacterNotFoundException
 import cloud.drakon.ktlodestone.exception.LodestoneException
-import cloud.drakon.ktlodestone.profile.ProfileClassJob
 import cloud.drakon.ktlodestone.profile.classjob.ClassJobLevel
 import cloud.drakon.ktlodestone.profile.classjob.Experience
+import cloud.drakon.ktlodestone.profile.classjob.ProfileClassJob
 import cloud.drakon.ktlodestone.profile.classjob.UniqueDutyLevel
 import io.ktor.client.call.body
 import io.ktor.client.request.get

--- a/src/main/kotlin/GearSet.kt
+++ b/src/main/kotlin/GearSet.kt
@@ -2,9 +2,9 @@ package cloud.drakon.ktlodestone
 
 import cloud.drakon.ktlodestone.exception.CharacterNotFoundException
 import cloud.drakon.ktlodestone.exception.LodestoneException
-import cloud.drakon.ktlodestone.profile.ProfileGearSet
-import cloud.drakon.ktlodestone.profile.gear.Gear
-import cloud.drakon.ktlodestone.profile.gear.Glamour
+import cloud.drakon.ktlodestone.profile.gearset.Gear
+import cloud.drakon.ktlodestone.profile.gearset.Glamour
+import cloud.drakon.ktlodestone.profile.gearset.ProfileGearSet
 import io.ktor.client.call.body
 import io.ktor.client.request.get
 import kotlinx.coroutines.async

--- a/src/main/kotlin/profile/ProfileCharacter.kt
+++ b/src/main/kotlin/profile/ProfileCharacter.kt
@@ -1,16 +1,18 @@
 package cloud.drakon.ktlodestone.profile
 
+import cloud.drakon.ktlodestone.profile.guild.Guild
+
 data class ProfileCharacter(
     val activeClassJob: ActiveClassJob,
     val avatar: String,
     val bio: String,
-    val freeCompany: FreeCompany?,
+    val freeCompany: Guild?,
     val grandCompany: GrandCompany?,
     val guardian: Guardian,
     val name: String,
     val nameday: String,
     val portrait: String,
-    val pvpTeam: PvpTeam?,
+    val pvpTeam: Guild?,
     val race: String,
     val clan: String,
     val gender: String,

--- a/src/main/kotlin/profile/attributes/ProfileAttributes.kt
+++ b/src/main/kotlin/profile/attributes/ProfileAttributes.kt
@@ -1,4 +1,4 @@
-package cloud.drakon.ktlodestone.profile
+package cloud.drakon.ktlodestone.profile.attributes
 
 /**
  * @property strength Affects physical damage dealt by gladiator's arms, marauder's arms, pugilist's arms, lancer's arms, conjurer's arms, thaumaturge's arms, arcanist's arms, dark knight's arms, samurai's arms, reaper's arms, gunbreaker's arms, red mage's arms, astrologian's arms, sage's arms, and blue mage's arms.

--- a/src/main/kotlin/profile/character/ActiveClassJob.kt
+++ b/src/main/kotlin/profile/character/ActiveClassJob.kt
@@ -1,3 +1,3 @@
-package cloud.drakon.ktlodestone.profile
+package cloud.drakon.ktlodestone.profile.character
 
 data class ActiveClassJob(val name: String, val level: Byte)

--- a/src/main/kotlin/profile/character/GrandCompany.kt
+++ b/src/main/kotlin/profile/character/GrandCompany.kt
@@ -1,3 +1,3 @@
-package cloud.drakon.ktlodestone.profile
+package cloud.drakon.ktlodestone.profile.character
 
 data class GrandCompany(val name: String, val rank: String, val icon: String)

--- a/src/main/kotlin/profile/character/Guardian.kt
+++ b/src/main/kotlin/profile/character/Guardian.kt
@@ -1,3 +1,3 @@
-package cloud.drakon.ktlodestone.profile
+package cloud.drakon.ktlodestone.profile.character
 
 data class Guardian(val name: String, val icon: String)

--- a/src/main/kotlin/profile/character/ProfileCharacter.kt
+++ b/src/main/kotlin/profile/character/ProfileCharacter.kt
@@ -1,4 +1,4 @@
-package cloud.drakon.ktlodestone.profile
+package cloud.drakon.ktlodestone.profile.character
 
 import cloud.drakon.ktlodestone.profile.guild.Guild
 

--- a/src/main/kotlin/profile/character/Town.kt
+++ b/src/main/kotlin/profile/character/Town.kt
@@ -1,3 +1,3 @@
-package cloud.drakon.ktlodestone.profile
+package cloud.drakon.ktlodestone.profile.character
 
 data class Town(val name: String, val icon: String)

--- a/src/main/kotlin/profile/classjob/ProfileClassJob.kt
+++ b/src/main/kotlin/profile/classjob/ProfileClassJob.kt
@@ -1,7 +1,4 @@
-package cloud.drakon.ktlodestone.profile
-
-import cloud.drakon.ktlodestone.profile.classjob.ClassJobLevel
-import cloud.drakon.ktlodestone.profile.classjob.UniqueDutyLevel
+package cloud.drakon.ktlodestone.profile.classjob
 
 data class ProfileClassJob(
     val bozja: UniqueDutyLevel?,

--- a/src/main/kotlin/profile/gearset/Gear.kt
+++ b/src/main/kotlin/profile/gearset/Gear.kt
@@ -1,4 +1,4 @@
-package cloud.drakon.ktlodestone.profile.gear
+package cloud.drakon.ktlodestone.profile.gearset
 
 data class Gear(
     val name: String,

--- a/src/main/kotlin/profile/gearset/Glamour.kt
+++ b/src/main/kotlin/profile/gearset/Glamour.kt
@@ -1,3 +1,3 @@
-package cloud.drakon.ktlodestone.profile.gear
+package cloud.drakon.ktlodestone.profile.gearset
 
 data class Glamour(val name: String, val dbLink: String)

--- a/src/main/kotlin/profile/gearset/ProfileGearSet.kt
+++ b/src/main/kotlin/profile/gearset/ProfileGearSet.kt
@@ -1,6 +1,4 @@
-package cloud.drakon.ktlodestone.profile
-
-import cloud.drakon.ktlodestone.profile.gear.Gear
+package cloud.drakon.ktlodestone.profile.gearset
 
 data class ProfileGearSet(
     val mainHand: Gear,

--- a/src/main/kotlin/profile/guild/Guild.kt
+++ b/src/main/kotlin/profile/guild/Guild.kt
@@ -1,4 +1,4 @@
-package cloud.drakon.ktlodestone.profile
+package cloud.drakon.ktlodestone.profile.guild
 
 data class Guild(val name: String, val id: String, val iconLayers: IconLayers)
 

--- a/src/main/kotlin/profile/guild/GuildType.kt
+++ b/src/main/kotlin/profile/guild/GuildType.kt
@@ -1,4 +1,4 @@
-package cloud.drakon.ktlodestone.profile
+package cloud.drakon.ktlodestone.profile.guild
 
 internal enum class GuildType {
     FREE_COMPANY, PVP_TEAM

--- a/src/main/kotlin/profile/guild/IconLayers.kt
+++ b/src/main/kotlin/profile/guild/IconLayers.kt
@@ -1,4 +1,4 @@
-package cloud.drakon.ktlodestone.profile
+package cloud.drakon.ktlodestone.profile.guild
 
 data class IconLayers(
     val bottom: String,


### PR DESCRIPTION
- Move `Guild`, `GuildType`, and `IconLayers`, to the `profile.guild` package
- Move `ActiveClassJob`, `GrandCompany` `Guardian`, `ProfileCharacter`, and `Town`, to the `profile.character` package
- Move `Gear`, `Glamour`, and `ProfileGearSet`, to the `profile.gearset` package
- Move `ProfileClassJob` to the `profile.classjob` package
- Move `ProfileAttributes` to the `profile.attributes` package