### PR TITLE
Move public functions to a single `KtLodestone` object

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -1,5 +1,6 @@
 <component name="ProjectCodeStyleConfiguration">
   <code_scheme name="Project" version="173">
+    <option name="ENABLE_SECOND_REFORMAT" value="true" />
     <JetCodeStyleSettings>
       <option name="PACKAGES_TO_USE_STAR_IMPORTS">
         <value />
@@ -16,6 +17,10 @@
       <option name="ALLOW_TRAILING_COMMA" value="true" />
       <option name="CODE_STYLE_DEFAULTS" value="KOTLIN_OFFICIAL" />
     </JetCodeStyleSettings>
+    <codeStyleSettings language="JAVA">
+      <option name="RIGHT_MARGIN" value="88" />
+      <option name="SOFT_MARGINS" value="88" />
+    </codeStyleSettings>
     <codeStyleSettings language="JSON">
       <indentOptions>
         <option name="INDENT_SIZE" value="4" />

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -17,7 +17,7 @@ plugins {
 }
 
 group = "cloud.drakon"
-version = "5.0.1-SNAPSHOT"
+version = "6.0.0-SNAPSHOT"
 
 repositories {
     mavenCentral()

--- a/src/main/kotlin/Attributes.kt
+++ b/src/main/kotlin/Attributes.kt
@@ -1,7 +1,5 @@
 package cloud.drakon.ktlodestone
 
-import cloud.drakon.ktlodestone.exception.CharacterNotFoundException
-import cloud.drakon.ktlodestone.exception.LodestoneException
 import cloud.drakon.ktlodestone.profile.attributes.ProfileAttributes
 import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
@@ -10,20 +8,14 @@ import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 import org.jsoup.nodes.Document
 
-object Attributes {
+internal object Attributes {
     private val lodestoneCssSelectors = Json.parseToJsonElement(
         this::class.java.classLoader.getResource("lodestone-css-selectors/profile/attributes.json") !!
             .readText()
     )
 
-    /**
-     * Gets the attributes of character from The Lodestone. This is equivalent to what is returned by The Lodestone's `/attributes` endpoint for a character.
-     * @param id The Lodestone character ID.
-     * @throws CharacterNotFoundException Thrown when a character could not be found on The Lodestone.
-     * @throws LodestoneException Thrown when The Lodestone returns an unknown error.
-     */
     suspend fun getAttributes(id: Int) = coroutineScope {
-        val character = getLodestoneProfile(id)
+        val character = KtLodestone.getLodestoneProfile(id)
 
         val strength = async {
             getAttributeCss(character, "STRENGTH").toShort()

--- a/src/main/kotlin/Character.kt
+++ b/src/main/kotlin/Character.kt
@@ -1,7 +1,5 @@
 package cloud.drakon.ktlodestone
 
-import cloud.drakon.ktlodestone.exception.CharacterNotFoundException
-import cloud.drakon.ktlodestone.exception.LodestoneException
 import cloud.drakon.ktlodestone.profile.character.ActiveClassJob
 import cloud.drakon.ktlodestone.profile.character.GrandCompany
 import cloud.drakon.ktlodestone.profile.character.Guardian
@@ -18,7 +16,7 @@ import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 import org.jsoup.nodes.Document
 
-object Character {
+internal object Character {
     private val lodestoneCssSelectors = Json.parseToJsonElement(
         this::class.java.classLoader.getResource("lodestone-css-selectors/profile/character.json") !!
             .readText()
@@ -30,14 +28,8 @@ object Character {
     private val serverRegex = """\S+""".toRegex()
     private val dcRegex = """(?<=\[)\w+(?=\])""".toRegex()
 
-    /**
-     * Gets a character's profile from The Lodestone.
-     * @param id The Lodestone character ID.
-     * @throws CharacterNotFoundException Thrown when a character could not be found on The Lodestone.
-     * @throws LodestoneException Thrown when The Lodestone returns an unknown error.
-     */
     suspend fun getCharacter(id: Int) = coroutineScope {
-        val character = getLodestoneProfile(id)
+        val character = KtLodestone.getLodestoneProfile(id)
 
         val activeClassJob = async { getActiveClassJob(character) }
 

--- a/src/main/kotlin/ClassJob.kt
+++ b/src/main/kotlin/ClassJob.kt
@@ -1,7 +1,5 @@
 package cloud.drakon.ktlodestone
 
-import cloud.drakon.ktlodestone.exception.CharacterNotFoundException
-import cloud.drakon.ktlodestone.exception.LodestoneException
 import cloud.drakon.ktlodestone.profile.classjob.ClassJobLevel
 import cloud.drakon.ktlodestone.profile.classjob.Experience
 import cloud.drakon.ktlodestone.profile.classjob.ProfileClassJob
@@ -13,7 +11,7 @@ import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 import org.jsoup.nodes.Document
 
-object ClassJob {
+internal object ClassJob {
     private val lodestoneCssSelectors = Json.parseToJsonElement(
         this::class.java.classLoader.getResource("lodestone-css-selectors/profile/classjob.json") !!
             .readText()
@@ -21,14 +19,8 @@ object ClassJob {
 
     private const val noExperience = "-- / --"
 
-    /**
-     * Gets a characters class/job stats from The Lodestone. This is equivalent to what is returned by The Lodestone's `/classjob` endpoint for a character.
-     * @param id The Lodestone character ID.
-     * @throws CharacterNotFoundException Thrown when a character could not be found on The Lodestone.
-     * @throws LodestoneException Thrown when The Lodestone returns an unknown error.
-     */
     suspend fun getClassJob(id: Int) = coroutineScope {
-        val character = getLodestoneProfile(id, "class_job")
+        val character = KtLodestone.getLodestoneProfile(id, "class_job")
 
         val bozja = async { getUniqueDutyLevel(character, "BOZJA") }
         val eureka = async { getUniqueDutyLevel(character, "EUREKA") }

--- a/src/main/kotlin/GearSet.kt
+++ b/src/main/kotlin/GearSet.kt
@@ -1,7 +1,5 @@
 package cloud.drakon.ktlodestone
 
-import cloud.drakon.ktlodestone.exception.CharacterNotFoundException
-import cloud.drakon.ktlodestone.exception.LodestoneException
 import cloud.drakon.ktlodestone.profile.gearset.Gear
 import cloud.drakon.ktlodestone.profile.gearset.Glamour
 import cloud.drakon.ktlodestone.profile.gearset.ProfileGearSet
@@ -13,20 +11,14 @@ import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 import org.jsoup.nodes.Document
 
-object GearSet {
+internal object GearSet {
     private val lodestoneCssSelectors = Json.parseToJsonElement(
         this::class.java.classLoader.getResource("lodestone-css-selectors/profile/gearset.json") !!
             .readText()
     )
 
-    /**
-     * Gets a characters equipped gear set from The Lodestone.
-     * @param id The Lodestone character ID.
-     * @throws CharacterNotFoundException Thrown when a character could not be found on The Lodestone.
-     * @throws LodestoneException Thrown when The Lodestone returns an unknown error.
-     */
     suspend fun getGearSet(id: Int) = coroutineScope {
-        val character = getLodestoneProfile(id)
+        val character = KtLodestone.getLodestoneProfile(id)
 
         val mainHand = async {
             getGearSetCss(character, "MAINHAND") !! // Cannot be null

--- a/src/main/kotlin/KtLodestone.kt
+++ b/src/main/kotlin/KtLodestone.kt
@@ -9,6 +9,7 @@ import io.ktor.client.request.get
 import io.ktor.client.request.header
 import io.ktor.http.HttpHeaders
 import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
@@ -24,12 +25,30 @@ object KtLodestone {
     suspend fun getAttributes(id: Int) = coroutineScope { Attributes.getAttributes(id) }
 
     /**
+     * Gets the attributes of a character from The Lodestone. This is equivalent to what is returned by The Lodestone's `/attributes` endpoint for a character. For use outside of Kotlin coroutines.
+     * @param id The Lodestone character ID.
+     * @throws CharacterNotFoundException Thrown when a character could not be found on The Lodestone.
+     * @throws LodestoneException Thrown when The Lodestone returns an unknown error.
+     */
+    @JvmStatic fun getAttributesBlocking(id: Int) =
+        runBlocking { Attributes.getAttributes(id) }
+
+    /**
      * Gets a character's profile from The Lodestone.
      * @param id The Lodestone character ID.
      * @throws CharacterNotFoundException Thrown when a character could not be found on The Lodestone.
      * @throws LodestoneException Thrown when The Lodestone returns an unknown error.
      */
     suspend fun getCharacter(id: Int) = coroutineScope { Character.getCharacter(id) }
+
+    /**
+     * Gets a character's profile from The Lodestone. For use outside of Kotlin coroutines.
+     * @param id The Lodestone character ID.
+     * @throws CharacterNotFoundException Thrown when a character could not be found on The Lodestone.
+     * @throws LodestoneException Thrown when The Lodestone returns an unknown error.
+     */
+    @JvmStatic fun getCharacterBlocking(id: Int) =
+        runBlocking { Character.getCharacter(id) }
 
     /**
      * Gets a characters class/job stats from The Lodestone. This is equivalent to what is returned by The Lodestone's `/class_job` endpoint for a character.
@@ -40,6 +59,15 @@ object KtLodestone {
     suspend fun getClassJob(id: Int) = coroutineScope { ClassJob.getClassJob(id) }
 
     /**
+     * Gets a characters class/job stats from The Lodestone. This is equivalent to what is returned by The Lodestone's `/class_job` endpoint for a character. For use outside of Kotlin coroutines.
+     * @param id The Lodestone character ID.
+     * @throws CharacterNotFoundException Thrown when a character could not be found on The Lodestone.
+     * @throws LodestoneException Thrown when The Lodestone returns an unknown error.
+     */
+    @JvmStatic fun getClassJobBlocking(id: Int) =
+        runBlocking { ClassJob.getClassJob(id) }
+
+    /**
      * Gets a characters equipped gear set from The Lodestone.
      * @param id The Lodestone character ID.
      * @throws CharacterNotFoundException Thrown when a character could not be found on The Lodestone.
@@ -48,12 +76,28 @@ object KtLodestone {
     suspend fun getGearSet(id: Int) = coroutineScope { GearSet.getGearSet(id) }
 
     /**
+     * Gets a characters equipped gear set from The Lodestone. For use outside of Kotlin coroutines.
+     * @param id The Lodestone character ID.
+     * @throws CharacterNotFoundException Thrown when a character could not be found on The Lodestone.
+     * @throws LodestoneException Thrown when The Lodestone returns an unknown error.
+     */
+    @JvmStatic fun getGearSetBlocking(id: Int) = runBlocking { GearSet.getGearSet(id) }
+
+    /**
      * Gets the minions that a character on The Lodestone has acquired. This is equivalent to what is returned by The Lodestone's `/minions` endpoint for a character.
      * @param id The Lodestone character ID.
      * @throws CharacterNotFoundException Thrown when a character could not be found on The Lodestone.
      * @throws LodestoneException Thrown when The Lodestone returns an unknown error.
      */
     suspend fun getMinions(id: Int) = coroutineScope { Minions.getMinions(id) }
+
+    /**
+     * Gets the minions that a character on The Lodestone has acquired. This is equivalent to what is returned by The Lodestone's `/minions` endpoint for a character. For use outside of Kotlin coroutines.
+     * @param id The Lodestone character ID.
+     * @throws CharacterNotFoundException Thrown when a character could not be found on The Lodestone.
+     * @throws LodestoneException Thrown when The Lodestone returns an unknown error.
+     */
+    @JvmStatic fun getMinionsBlocking(id: Int) = runBlocking { Minions.getMinions(id) }
 
     private val meta = Json.parseToJsonElement(
         object {}::class.java.classLoader.getResource("lodestone-css-selectors/meta.json") !!

--- a/src/main/kotlin/KtLodestone.kt
+++ b/src/main/kotlin/KtLodestone.kt
@@ -14,42 +14,84 @@ import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 import org.jsoup.Jsoup
 
-private val meta = Json.parseToJsonElement(
-    object {}::class.java.classLoader.getResource("lodestone-css-selectors/meta.json") !!
-        .readText()
-)
+object KtLodestone {
+    /**
+     * Gets the attributes of a character from The Lodestone. This is equivalent to what is returned by The Lodestone's `/attributes` endpoint for a character.
+     * @param id The Lodestone character ID.
+     * @throws CharacterNotFoundException Thrown when a character could not be found on The Lodestone.
+     * @throws LodestoneException Thrown when The Lodestone returns an unknown error.
+     */
+    suspend fun getAttributes(id: Int) = coroutineScope { Attributes.getAttributes(id) }
 
-private val userAgentDesktop =
-    meta.jsonObject["userAgentDesktop"] !!.jsonPrimitive.content
-private val userAgentMobile =
-    meta.jsonObject["userAgentMobile"] !!.jsonPrimitive.content
+    /**
+     * Gets a character's profile from The Lodestone.
+     * @param id The Lodestone character ID.
+     * @throws CharacterNotFoundException Thrown when a character could not be found on The Lodestone.
+     * @throws LodestoneException Thrown when The Lodestone returns an unknown error.
+     */
+    suspend fun getCharacter(id: Int) = coroutineScope { Character.getCharacter(id) }
 
-private val ktorClient = HttpClient(Java)
+    /**
+     * Gets a characters class/job stats from The Lodestone. This is equivalent to what is returned by The Lodestone's `/class_job` endpoint for a character.
+     * @param id The Lodestone character ID.
+     * @throws CharacterNotFoundException Thrown when a character could not be found on The Lodestone.
+     * @throws LodestoneException Thrown when The Lodestone returns an unknown error.
+     */
+    suspend fun getClassJob(id: Int) = coroutineScope { ClassJob.getClassJob(id) }
 
-internal suspend fun getLodestoneProfile(
-    id: Int,
-    endpoint: String? = null,
-    mobileUserAgent: Boolean = false,
-) = coroutineScope {
-    val url = if (endpoint == null) {
-        "https://eu.finalfantasyxiv.com/lodestone/character/${id}/"
-    } else {
-        "https://eu.finalfantasyxiv.com/lodestone/character/${id}/${endpoint}"
-    }
+    /**
+     * Gets a characters equipped gear set from The Lodestone.
+     * @param id The Lodestone character ID.
+     * @throws CharacterNotFoundException Thrown when a character could not be found on The Lodestone.
+     * @throws LodestoneException Thrown when The Lodestone returns an unknown error.
+     */
+    suspend fun getGearSet(id: Int) = coroutineScope { GearSet.getGearSet(id) }
 
-    val request = ktorClient.get(url) {
-        header(
-            HttpHeaders.UserAgent, if (! mobileUserAgent) {
-                userAgentDesktop
-            } else {
-                userAgentMobile
-            }
-        )
-    }
+    /**
+     * Gets the minions that a character on The Lodestone has acquired. This is equivalent to what is returned by The Lodestone's `/minions` endpoint for a character.
+     * @param id The Lodestone character ID.
+     * @throws CharacterNotFoundException Thrown when a character could not be found on The Lodestone.
+     * @throws LodestoneException Thrown when The Lodestone returns an unknown error.
+     */
+    suspend fun getMinions(id: Int) = coroutineScope { Minions.getMinions(id) }
 
-    return@coroutineScope when (request.status.value) {
-        200 -> Jsoup.parse(request.body() as String)
-        404 -> throw CharacterNotFoundException("A character with ID `${id}` could not be found on The Lodestone.")
-        else -> throw LodestoneException("The Lodestone returned an unknown error.")
+    private val meta = Json.parseToJsonElement(
+        object {}::class.java.classLoader.getResource("lodestone-css-selectors/meta.json") !!
+            .readText()
+    )
+
+    private val userAgentDesktop =
+        meta.jsonObject["userAgentDesktop"] !!.jsonPrimitive.content
+    private val userAgentMobile =
+        meta.jsonObject["userAgentMobile"] !!.jsonPrimitive.content
+
+    private val ktorClient = HttpClient(Java)
+
+    internal suspend fun getLodestoneProfile(
+        id: Int,
+        endpoint: String? = null,
+        mobileUserAgent: Boolean = false,
+    ) = coroutineScope {
+        val url = if (endpoint == null) {
+            "https://eu.finalfantasyxiv.com/lodestone/character/${id}/"
+        } else {
+            "https://eu.finalfantasyxiv.com/lodestone/character/${id}/${endpoint}"
+        }
+
+        val request = ktorClient.get(url) {
+            header(
+                HttpHeaders.UserAgent, if (! mobileUserAgent) {
+                    userAgentDesktop
+                } else {
+                    userAgentMobile
+                }
+            )
+        }
+
+        return@coroutineScope when (request.status.value) {
+            200 -> Jsoup.parse(request.body() as String)
+            404 -> throw CharacterNotFoundException("A character with ID `${id}` could not be found on The Lodestone.")
+            else -> throw LodestoneException("The Lodestone returned an unknown error.")
+        }
     }
 }

--- a/src/main/kotlin/Minions.kt
+++ b/src/main/kotlin/Minions.kt
@@ -1,7 +1,5 @@
 package cloud.drakon.ktlodestone
 
-import cloud.drakon.ktlodestone.exception.CharacterNotFoundException
-import cloud.drakon.ktlodestone.exception.LodestoneException
 import cloud.drakon.ktlodestone.profile.minions.Minion
 import cloud.drakon.ktlodestone.profile.minions.ProfileMinions
 import kotlinx.coroutines.async
@@ -12,20 +10,15 @@ import kotlinx.serialization.json.jsonPrimitive
 import org.jsoup.nodes.Document
 import org.jsoup.nodes.Element
 
-object Minions {
+internal object Minions {
     private val lodestoneCssSelectors = Json.parseToJsonElement(
         this::class.java.classLoader.getResource("lodestone-css-selectors/profile/minion.json") !!
             .readText()
     )
 
-    /**
-     * Gets the minions that a character on The Lodestone has acquired.
-     * @param id The Lodestone character ID.
-     * @throws CharacterNotFoundException Thrown when a character could not be found on The Lodestone.
-     * @throws LodestoneException Thrown when The Lodestone returns an unknown error.
-     */
     suspend fun getMinions(id: Int) = coroutineScope {
-        val character = getLodestoneProfile(id, "minion", mobileUserAgent = true)
+        val character =
+            KtLodestone.getLodestoneProfile(id, "minion", mobileUserAgent = true)
 
         val minions = async {
             getMinionList(character)

--- a/src/test/java/AttributesTestJava.java
+++ b/src/test/java/AttributesTestJava.java
@@ -1,0 +1,18 @@
+import cloud.drakon.ktlodestone.KtLodestone;
+import cloud.drakon.ktlodestone.exception.CharacterNotFoundException;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class AttributesTestJava {
+    @Test
+    void getCharacter() {
+        assertDoesNotThrow(() -> KtLodestone.getAttributesBlocking(27545492));
+    }
+
+    @Test
+    void getInvalidCharacter() {
+        assertThrows(CharacterNotFoundException.class, () -> KtLodestone.getAttributesBlocking(0));
+    }
+}

--- a/src/test/java/CharacterTestJava.java
+++ b/src/test/java/CharacterTestJava.java
@@ -1,0 +1,18 @@
+import cloud.drakon.ktlodestone.KtLodestone;
+import cloud.drakon.ktlodestone.exception.CharacterNotFoundException;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class CharacterTestJava {
+    @Test
+    void getCharacter() {
+        assertDoesNotThrow(() -> KtLodestone.getCharacterBlocking(27545492));
+    }
+
+    @Test
+    void getInvalidCharacter() {
+        assertThrows(CharacterNotFoundException.class, () -> KtLodestone.getCharacterBlocking(0));
+    }
+}

--- a/src/test/java/ClassJobTestJava.java
+++ b/src/test/java/ClassJobTestJava.java
@@ -1,0 +1,18 @@
+import cloud.drakon.ktlodestone.KtLodestone;
+import cloud.drakon.ktlodestone.exception.CharacterNotFoundException;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class ClassJobTestJava {
+    @Test
+    void getCharacter() {
+        assertDoesNotThrow(() -> KtLodestone.getClassJobBlocking(27545492));
+    }
+
+    @Test
+    void getInvalidCharacter() {
+        assertThrows(CharacterNotFoundException.class, () -> KtLodestone.getClassJobBlocking(0));
+    }
+}

--- a/src/test/java/GearSetTestJava.java
+++ b/src/test/java/GearSetTestJava.java
@@ -1,0 +1,18 @@
+import cloud.drakon.ktlodestone.KtLodestone;
+import cloud.drakon.ktlodestone.exception.CharacterNotFoundException;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class GearSetTestJava {
+    @Test
+    void getCharacter() {
+        assertDoesNotThrow(() -> KtLodestone.getGearSetBlocking(27545492));
+    }
+
+    @Test
+    void getInvalidCharacter() {
+        assertThrows(CharacterNotFoundException.class, () -> KtLodestone.getGearSetBlocking(0));
+    }
+}

--- a/src/test/java/MinionsTestJava.java
+++ b/src/test/java/MinionsTestJava.java
@@ -1,0 +1,18 @@
+import cloud.drakon.ktlodestone.KtLodestone;
+import cloud.drakon.ktlodestone.exception.CharacterNotFoundException;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class MinionsTestJava {
+    @Test
+    void getCharacter() {
+        assertDoesNotThrow(() -> KtLodestone.getMinionsBlocking(27545492));
+    }
+
+    @Test
+    void getInvalidCharacter() {
+        assertThrows(CharacterNotFoundException.class, () -> KtLodestone.getMinionsBlocking(0));
+    }
+}

--- a/src/test/kotlin/AttributesTest.kt
+++ b/src/test/kotlin/AttributesTest.kt
@@ -1,4 +1,4 @@
-import cloud.drakon.ktlodestone.Attributes
+import cloud.drakon.ktlodestone.KtLodestone
 import cloud.drakon.ktlodestone.exception.CharacterNotFoundException
 import kotlin.test.Test
 import kotlinx.coroutines.runBlocking
@@ -9,7 +9,7 @@ class AttributesTest {
     @Test fun getAttributes() {
         Assertions.assertDoesNotThrow {
             return@assertDoesNotThrow runBlocking {
-                println(Attributes.getAttributes(27545492))
+                println(KtLodestone.getAttributes(27545492))
             }
         }
     }
@@ -17,7 +17,7 @@ class AttributesTest {
     @Test fun getInvalidCharacter() {
         assertThrows<CharacterNotFoundException> {
             return@assertThrows runBlocking {
-                println(Attributes.getAttributes(0))
+                println(KtLodestone.getAttributes(0))
             }
         }
     }

--- a/src/test/kotlin/CharacterTest.kt
+++ b/src/test/kotlin/CharacterTest.kt
@@ -1,4 +1,4 @@
-import cloud.drakon.ktlodestone.Character
+import cloud.drakon.ktlodestone.KtLodestone
 import cloud.drakon.ktlodestone.exception.CharacterNotFoundException
 import kotlin.test.Test
 import kotlinx.coroutines.runBlocking
@@ -9,7 +9,7 @@ class CharacterTest {
     @Test fun getCharacter() {
         assertDoesNotThrow {
             return@assertDoesNotThrow runBlocking {
-                println(Character.getCharacter(27545492))
+                println(KtLodestone.getCharacter(27545492))
             }
         }
     }
@@ -17,7 +17,7 @@ class CharacterTest {
     @Test fun getInvalidCharacter() {
         assertThrows<CharacterNotFoundException> {
             return@assertThrows runBlocking {
-                println(Character.getCharacter(0))
+                println(KtLodestone.getCharacter(0))
             }
         }
     }

--- a/src/test/kotlin/ClassJobTest.kt
+++ b/src/test/kotlin/ClassJobTest.kt
@@ -1,4 +1,4 @@
-import cloud.drakon.ktlodestone.ClassJob
+import cloud.drakon.ktlodestone.KtLodestone
 import cloud.drakon.ktlodestone.exception.CharacterNotFoundException
 import kotlin.test.Test
 import kotlinx.coroutines.runBlocking
@@ -9,7 +9,7 @@ class ClassJobTest {
     @Test fun getClassJob() {
         Assertions.assertDoesNotThrow {
             return@assertDoesNotThrow runBlocking {
-                println(ClassJob.getClassJob(27545492))
+                println(KtLodestone.getClassJob(27545492))
             }
         }
     }
@@ -17,7 +17,7 @@ class ClassJobTest {
     @Test fun getInvalidClassJob() {
         assertThrows<CharacterNotFoundException> {
             return@assertThrows runBlocking {
-                println(ClassJob.getClassJob(0))
+                println(KtLodestone.getClassJob(0))
             }
         }
     }

--- a/src/test/kotlin/GearSetTest.kt
+++ b/src/test/kotlin/GearSetTest.kt
@@ -1,4 +1,4 @@
-import cloud.drakon.ktlodestone.GearSet
+import cloud.drakon.ktlodestone.KtLodestone
 import cloud.drakon.ktlodestone.exception.CharacterNotFoundException
 import kotlin.test.Test
 import kotlinx.coroutines.runBlocking
@@ -9,7 +9,7 @@ class GearSetTest {
     @Test fun getAttributes() {
         Assertions.assertDoesNotThrow {
             return@assertDoesNotThrow runBlocking {
-                println(GearSet.getGearSet(27545492))
+                println(KtLodestone.getGearSet(27545492))
             }
         }
     }
@@ -17,7 +17,7 @@ class GearSetTest {
     @Test fun getInvalidCharacter() {
         assertThrows<CharacterNotFoundException> {
             return@assertThrows runBlocking {
-                println(GearSet.getGearSet(0))
+                println(KtLodestone.getGearSet(0))
             }
         }
     }

--- a/src/test/kotlin/MinionsTest.kt
+++ b/src/test/kotlin/MinionsTest.kt
@@ -1,4 +1,4 @@
-import cloud.drakon.ktlodestone.Minions
+import cloud.drakon.ktlodestone.KtLodestone
 import cloud.drakon.ktlodestone.exception.CharacterNotFoundException
 import kotlin.test.Test
 import kotlinx.coroutines.runBlocking
@@ -9,7 +9,7 @@ class MinionsTest {
     @Test fun getMinions() {
         Assertions.assertDoesNotThrow {
             return@assertDoesNotThrow runBlocking {
-                println(Minions.getMinions(27545492))
+                println(KtLodestone.getMinions(27545492))
             }
         }
     }
@@ -17,7 +17,7 @@ class MinionsTest {
     @Test fun getInvalidMinions() {
         assertThrows<CharacterNotFoundException> {
             return@assertThrows runBlocking {
-                println(Minions.getMinions(0))
+                println(KtLodestone.getMinions(0))
             }
         }
     }


### PR DESCRIPTION
- Move public functions to a single KtLodestone object
  - This simplifies the documentation and makes code using the library more understandable as everything is a descendent of `KtLodestone` rather than the previous Object names
- Create blocking functions for use outside of Kotlin coroutines
  - This allows the library to be used from Java and other JVM languages