### PR TITLE
`ProfileClassJob` should contains `Map`s instead of `data class`es

### DIFF
--- a/src/main/kotlin/profile/classjob/ClassJobName.kt
+++ b/src/main/kotlin/profile/classjob/ClassJobName.kt
@@ -1,0 +1,99 @@
+package cloud.drakon.ktlodestone.profile.classjob
+
+/**
+ * An [Enum] who's values consist of job names.
+ */
+enum class ClassJobName {
+    /** Paladin/Gladiator */
+    PALADIN,
+
+    /** Warrior/Marauder */
+    WARRIOR,
+
+    /** Dark Knight */
+    DARKKNIGHT,
+
+    /** Gunbreaker */
+    GUNBREAKER,
+
+    /** White Mage/Conjurer */
+    WHITEMAGE,
+
+    /** Scholar/Arcanist */
+    SCHOLAR,
+
+    /** Astrologian */
+    ASTROLOGIAN,
+
+    /** Sage */
+    SAGE,
+
+    /** Monk/Pugilist */
+    MONK,
+
+    /** Dragoon/Lancer */
+    DRAGOON,
+
+    /** Ninja/Rogue */
+    NINJA,
+
+    /** Samurai */
+    SAMURAI,
+
+    /** Reaper */
+    REAPER,
+
+    /** Bard/Archer */
+    BARD,
+
+    /** Machinist */
+    MACHINIST,
+
+    /** Dancer */
+    DANCER,
+
+    /** Black Mage/Thaumaturge */
+    BLACKMAGE,
+
+    /** Summoner/Arcanist */
+    SUMMONER,
+
+    /** Red Mage */
+    REDMAGE,
+
+    /** Blue Mage */
+    BLUEMAGE,
+
+    /** Carpenter */
+    CARPENTER,
+
+    /** Blacksmith */
+    BLACKSMITH,
+
+    /** Armorer */
+    ARMORER,
+
+    /** Goldsmith */
+    GOLDSMITH,
+
+    /** Leatherworker */
+    LEATHERWORKER,
+
+    /** Weaver */
+    WEAVER,
+
+    /** Alchemist */
+    ALCHEMIST,
+
+    /** Culinarian */
+    CULINARIAN,
+
+    /** Miner */
+    MINER,
+
+    /** Botanist */
+    BOTANIST,
+
+    /** Fisher */
+    FISHER,
+}

--- a/src/main/kotlin/profile/classjob/ProfileClassJob.kt
+++ b/src/main/kotlin/profile/classjob/ProfileClassJob.kt
@@ -1,73 +1,11 @@
 package cloud.drakon.ktlodestone.profile.classjob
 
 /**
- * The levels that a character has in all jobs/classes and unique duties.
- * @property bozja The Resistance Rank of a character.
- * @property eureka The Elemental Level of a character.
- * @property paladin The level of the Paladin/Gladiator job/class of a character.
- * @property warrior The level of the Warrior/Marauder job/class of a character.
- * @property darkKnight The level of the Dark Knight job of a character.
- * @property gunbreaker The level of the Gunbreaker job of a character.
- * @property whiteMage The level of the White Mage/Conjurer job/class of a character.
- * @property scholar The level of the Scholar/Arcanist job/class of a character.
- * @property astrologian The level of the Astrologian job of a character.
- * @property sage The level of the Sage job of a character.
- * @property monk The level of the Monk/Pugilist job/class of a character.
- * @property dragoon The level of the Dragoon/Lancer job/class of a character.
- * @property ninja The level of the Ninja/Rogue job of a character.
- * @property samurai The level of the Samurai job of a character.
- * @property reaper The level of the Reaper job of a character.
- * @property bard The level of the Bard/Archer job/class of a character.
- * @property machinist The level of the Machinist job of a character.
- * @property dancer The level of the Dancer job of a character.
- * @property blackMage The level of the Black Mage/Thaumaturge job/class of a character.
- * @property summoner The level of the Summer/Arcanist job/class of a character.
- * @property redMage The level of the Red Mage job of a character.
- * @property blueMage The level of the Blue Mage limited job of a character.
- * @property carpenter The level of the Carpenter class of a character.
- * @property blacksmith The level of the Blacksmith class of a character.
- * @property armorer The level of the Armorer class of a character.
- * @property goldsmith The level of the Goldsmith class of a character.
- * @property leatherworker The level of the Leatherworker class of a character.
- * @property weaver The level of the Weaver class of a character.
- * @property alchemist The level of the Alchemist class of a character.
- * @property culinarian The level of the Culinarian class of a character.
- * @property miner The level of the Miner class of a character.
- * @property botanist The level of the Botanist class of a character.
- * @property fisher The level of the Fisher class of a character.
+ * The level(s) that a character has in their unlocked classes/jobs and unique duties.
+ * @property classJob A [Map] of [ClassJobName] to [ClassJobLevel].
+ * @property uniqueDuty A [Map] of [UniqueDutyName] to [UniqueDutyLevel].
  */
 data class ProfileClassJob(
-    val bozja: UniqueDutyLevel?,
-    val eureka: UniqueDutyLevel?,
-    val paladin: ClassJobLevel?,
-    val warrior: ClassJobLevel?,
-    val darkKnight: ClassJobLevel?,
-    val gunbreaker: ClassJobLevel?,
-    val whiteMage: ClassJobLevel?,
-    val scholar: ClassJobLevel?,
-    val astrologian: ClassJobLevel?,
-    val sage: ClassJobLevel?,
-    val monk: ClassJobLevel?,
-    val dragoon: ClassJobLevel?,
-    val ninja: ClassJobLevel?,
-    val samurai: ClassJobLevel?,
-    val reaper: ClassJobLevel?,
-    val bard: ClassJobLevel?,
-    val machinist: ClassJobLevel?,
-    val dancer: ClassJobLevel?,
-    val blackMage: ClassJobLevel?,
-    val summoner: ClassJobLevel?,
-    val redMage: ClassJobLevel?,
-    val blueMage: ClassJobLevel?,
-    val carpenter: ClassJobLevel?,
-    val blacksmith: ClassJobLevel?,
-    val armorer: ClassJobLevel?,
-    val goldsmith: ClassJobLevel?,
-    val leatherworker: ClassJobLevel?,
-    val weaver: ClassJobLevel?,
-    val alchemist: ClassJobLevel?,
-    val culinarian: ClassJobLevel?,
-    val miner: ClassJobLevel?,
-    val botanist: ClassJobLevel?,
-    val fisher: ClassJobLevel?,
+    val classJob: Map<ClassJobName, ClassJobLevel?>,
+    val uniqueDuty: Map<UniqueDutyName, UniqueDutyLevel?>,
 )

--- a/src/main/kotlin/profile/classjob/UniqueDutyLevel.kt
+++ b/src/main/kotlin/profile/classjob/UniqueDutyLevel.kt
@@ -6,8 +6,3 @@ package cloud.drakon.ktlodestone.profile.classjob
  * @property experience The experience that a character has in the unique duty.
  */
 data class UniqueDutyLevel(val level: Byte, val experience: Experience?)
-
-/** The Elemental Level of a character. */
-typealias Eureka = UniqueDutyLevel
-/** The Resistance Rank of a character. */
-typealias Bozja = UniqueDutyLevel

--- a/src/main/kotlin/profile/classjob/UniqueDutyName.kt
+++ b/src/main/kotlin/profile/classjob/UniqueDutyName.kt
@@ -1,0 +1,12 @@
+package cloud.drakon.ktlodestone.profile.classjob
+
+/**
+ * An [Enum] who's values consist of unique duties that appear on a characters Lodestone profile.
+ */
+enum class UniqueDutyName {
+    /** The Forbidden Land: Eureka Anemos/Pagos/Pyros/Hydatos */
+    EUREKA,
+
+    /** Bozjan Southern Front and Zadnor */
+    BOZJA
+}


### PR DESCRIPTION
This significantly simplifies the constructor of the `ProfileClassJob` class. It now only contains two properties:

- `classJob` which is a `Map` of the `ClassJobName` enum to `ClassJobLevel`
- `uniqueDuty` which is a `Map` of the `UniqueDutyName` enum to `UniqueDutyLevel`

Also removes the type aliases for `UniqueDutyLevel`.