### PR TITLE
Optionally return character achievements

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # KtLodestone
 
-![Kotlin Alpha](https://kotl.in/badges/alpha.svg)
+![Kotlin Beta](https://kotl.in/badges/beta.svg)
 [![Kotlin](https://img.shields.io/badge/kotlin-1.8.21-blue.svg?logo=kotlin)](http://kotlinlang.org)
 [![License](https://img.shields.io/github/license/drakon64/KtLodestone)](hhttps://opensource.org/license/mit/)
 [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=KtLodestone&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=KtLodestone)
@@ -14,6 +14,7 @@ KtLodestone is a parser for The Lodestone for the JVM platform (JDK 11+).
 - Supports scraping the following information from The Lodestone:
   - Character
     - Profile
+    - Achievements
     - Attributes
     - Class/job
     - Equipped gear
@@ -32,7 +33,7 @@ KtLodestone is a parser for The Lodestone for the JVM platform (JDK 11+).
 KtLodestone is available from Maven Central:
 ```kotlin
 dependencies {
-    implementation("cloud.drakon.ktlodestone:6.0.0")
+    implementation("cloud.drakon.ktlodestone:6.1.0")
 }
 ```
 
@@ -40,7 +41,7 @@ dependencies {
 
 ---
 
-Kotlin KDocs: [![kdoc](https://img.shields.io/badge/kdoc-6.0.0-brightgreen)](https://drakon64.github.io/KtLodestone/)<br>
+Kotlin KDocs: [![kdoc](https://img.shields.io/badge/kdoc-6.1.0-brightgreen)](https://drakon64.github.io/KtLodestone/)<br>
 Javadocs: [![javadoc](https://javadoc.io/badge2/cloud.drakon/ktlodestone/javadoc.svg)](https://javadoc.io/doc/cloud.drakon/ktlodestone)
 
 # Examples

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -17,7 +17,7 @@ plugins {
 }
 
 group = "cloud.drakon"
-version = "6.1.0-SNAPSHOT"
+version = "6.1.0"
 
 repositories {
     mavenCentral()

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -17,7 +17,7 @@ plugins {
 }
 
 group = "cloud.drakon"
-version = "6.0.0"
+version = "6.1.0-SNAPSHOT"
 
 repositories {
     mavenCentral()

--- a/src/main/kotlin/KtLodestone.kt
+++ b/src/main/kotlin/KtLodestone.kt
@@ -4,6 +4,7 @@ package cloud.drakon.ktlodestone
 
 import cloud.drakon.ktlodestone.exception.CharacterNotFoundException
 import cloud.drakon.ktlodestone.exception.LodestoneException
+import cloud.drakon.ktlodestone.profile.Achievements
 import cloud.drakon.ktlodestone.profile.Attributes
 import cloud.drakon.ktlodestone.profile.Character
 import cloud.drakon.ktlodestone.profile.ClassJob
@@ -26,6 +27,24 @@ import kotlinx.serialization.json.jsonPrimitive
 import org.jsoup.Jsoup
 
 object KtLodestone {
+    /**
+     * Gets the achievements of a character from The Lodestone. This is equivalent to what is returned by The Lodestone's `/achievement` endpoint for a character.
+     * @param id The Lodestone character ID.
+     * @throws CharacterNotFoundException Thrown when a character could not be found on The Lodestone.
+     * @throws LodestoneException Thrown when The Lodestone returns an unknown error.
+     */
+    suspend fun getAchievements(id: Int) =
+        coroutineScope { Achievements.getAchievements(id) }
+
+    /**
+     * Gets the achievements of a character from The Lodestone. This is equivalent to what is returned by The Lodestone's `/achievement` endpoint for a character. For use outside of Kotlin coroutines.
+     * @param id The Lodestone character ID.
+     * @throws CharacterNotFoundException Thrown when a character could not be found on The Lodestone.
+     * @throws LodestoneException Thrown when The Lodestone returns an unknown error.
+     */
+    @JvmStatic fun getAchievementsAsync(id: Int) =
+        GlobalScope.future { Achievements.getAchievements(id) }
+
     /**
      * Gets the attributes of a character from The Lodestone. This is equivalent to what is returned by The Lodestone's `#profile` endpoint for a character.
      * @param id The Lodestone character ID.

--- a/src/main/kotlin/KtLodestone.kt
+++ b/src/main/kotlin/KtLodestone.kt
@@ -153,12 +153,12 @@ object KtLodestone {
             .readText()
     )
 
-    internal val userAgentDesktop =
+    private val userAgentDesktop =
         meta.jsonObject["userAgentDesktop"] !!.jsonPrimitive.content
     private val userAgentMobile =
         meta.jsonObject["userAgentMobile"] !!.jsonPrimitive.content
 
-    internal val ktorClient = HttpClient(Java)
+    private val ktorClient = HttpClient(Java)
 
     internal suspend fun getLodestoneProfile(
         id: Int,
@@ -187,4 +187,17 @@ object KtLodestone {
             else -> throw LodestoneException()
         }
     }
+
+    internal suspend fun getLodestoneProfilePaginated(endpoint: String) =
+        coroutineScope {
+            val request = ktorClient.get(endpoint) {
+                header(HttpHeaders.UserAgent, userAgentDesktop)
+            }
+
+            return@coroutineScope if (request.status.value == 200) {
+                Jsoup.parse(request.body() as String)
+            } else {
+                throw LodestoneException()
+            }
+        }
 }

--- a/src/main/kotlin/KtLodestone.kt
+++ b/src/main/kotlin/KtLodestone.kt
@@ -30,20 +30,22 @@ object KtLodestone {
     /**
      * Gets the achievements of a character from The Lodestone. This is equivalent to what is returned by The Lodestone's `/achievement` endpoint for a character.
      * @param id The Lodestone character ID.
+     * @param pages The number of pages to get achievements from
      * @throws CharacterNotFoundException Thrown when a character could not be found on The Lodestone.
      * @throws LodestoneException Thrown when The Lodestone returns an unknown error.
      */
-    suspend fun getAchievements(id: Int) =
-        coroutineScope { Achievements.getAchievements(id) }
+    suspend fun getAchievements(id: Int, pages: UByte? = null) =
+        coroutineScope { Achievements.getAchievements(id, pages) }
 
     /**
      * Gets the achievements of a character from The Lodestone. This is equivalent to what is returned by The Lodestone's `/achievement` endpoint for a character. For use outside of Kotlin coroutines.
      * @param id The Lodestone character ID.
+     * * @param pages The number of pages to get achievements from
      * @throws CharacterNotFoundException Thrown when a character could not be found on The Lodestone.
      * @throws LodestoneException Thrown when The Lodestone returns an unknown error.
      */
-    @JvmStatic fun getAchievementsAsync(id: Int) =
-        GlobalScope.future { Achievements.getAchievements(id) }
+    @JvmStatic fun getAchievementsAsync(id: Int, pages: UByte? = null) =
+        GlobalScope.future { Achievements.getAchievements(id, pages) }
 
     /**
      * Gets the attributes of a character from The Lodestone. This is equivalent to what is returned by The Lodestone's `#profile` endpoint for a character.

--- a/src/main/kotlin/KtLodestone.kt
+++ b/src/main/kotlin/KtLodestone.kt
@@ -184,7 +184,7 @@ object KtLodestone {
         return@coroutineScope when (request.status.value) {
             200 -> Jsoup.parse(request.body() as String)
             404 -> throw CharacterNotFoundException("A character with ID `${id}` could not be found on The Lodestone.")
-            else -> throw LodestoneException("The Lodestone returned an unknown error.")
+            else -> throw LodestoneException()
         }
     }
 }

--- a/src/main/kotlin/KtLodestone.kt
+++ b/src/main/kotlin/KtLodestone.kt
@@ -151,12 +151,12 @@ object KtLodestone {
             .readText()
     )
 
-    private val userAgentDesktop =
+    internal val userAgentDesktop =
         meta.jsonObject["userAgentDesktop"] !!.jsonPrimitive.content
     private val userAgentMobile =
         meta.jsonObject["userAgentMobile"] !!.jsonPrimitive.content
 
-    private val ktorClient = HttpClient(Java)
+    internal val ktorClient = HttpClient(Java)
 
     internal suspend fun getLodestoneProfile(
         id: Int,

--- a/src/main/kotlin/KtLodestone.kt
+++ b/src/main/kotlin/KtLodestone.kt
@@ -34,7 +34,7 @@ object KtLodestone {
      * @throws CharacterNotFoundException Thrown when a character could not be found on The Lodestone.
      * @throws LodestoneException Thrown when The Lodestone returns an unknown error.
      */
-    suspend fun getAchievements(id: Int, pages: UByte? = null) =
+    suspend fun getAchievements(id: Int, pages: Byte? = null) =
         coroutineScope { Achievements.getAchievements(id, pages) }
 
     /**
@@ -44,7 +44,7 @@ object KtLodestone {
      * @throws CharacterNotFoundException Thrown when a character could not be found on The Lodestone.
      * @throws LodestoneException Thrown when The Lodestone returns an unknown error.
      */
-    @JvmStatic fun getAchievementsAsync(id: Int, pages: UByte? = null) =
+    @JvmStatic fun getAchievementsAsync(id: Int, pages: Byte? = null) =
         GlobalScope.future { Achievements.getAchievements(id, pages) }
 
     /**

--- a/src/main/kotlin/exception/LodestoneException.kt
+++ b/src/main/kotlin/exception/LodestoneException.kt
@@ -3,4 +3,5 @@ package cloud.drakon.ktlodestone.exception
 /**
  * Thrown when The Lodestone returns an unknown error.
  */
-class LodestoneException(override val message: String): Throwable(message)
+class LodestoneException(override val message: String = "The Lodestone returned an unknown error."):
+    Throwable(message)

--- a/src/main/kotlin/exception/PagesLessThanOneException.kt
+++ b/src/main/kotlin/exception/PagesLessThanOneException.kt
@@ -1,0 +1,6 @@
+package cloud.drakon.ktlodestone.exception
+
+/**
+ * Thrown when less than one page is requested with a `page` parameter.
+ */
+class PagesLessThanOneException(override val message: String): Throwable(message)

--- a/src/main/kotlin/profile/Achievements.kt
+++ b/src/main/kotlin/profile/Achievements.kt
@@ -1,0 +1,92 @@
+package cloud.drakon.ktlodestone.profile
+
+import cloud.drakon.ktlodestone.KtLodestone
+import cloud.drakon.ktlodestone.profile.achievements.Achievement
+import cloud.drakon.ktlodestone.profile.achievements.ProfileAchievements
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import org.jsoup.nodes.Document
+
+internal object Achievements {
+    private val lodestoneCssSelectors = Json.parseToJsonElement(
+        this::class.java.classLoader.getResource("lodestone-css-selectors/profile/achievements.json") !!
+            .readText()
+    )
+
+    suspend fun getAchievements(id: Int) = coroutineScope {
+        val character = KtLodestone.getLodestoneProfile(id, "achievement")
+
+        val achievements = async { getProfileAchievements(character) }
+
+        val totalAchievements = async {
+            getAchievementCount(character, "TOTAL_ACHIEVEMENTS")
+        }
+
+        val achievementPoints = async {
+            getAchievementCount(character, "ACHIEVEMENT_POINTS")
+        }
+
+        return@coroutineScope ProfileAchievements(
+            achievements.await(), totalAchievements.await(), achievementPoints.await()
+        )
+    }
+
+    private val achievementNameRegex = """"([^"]*)"""".toRegex()
+    private val achievementIdRegex = """\d+(?=\/$)""".toRegex()
+    private val achievementDateRegex = """(?<=ldst_strftime\()\d+""".toRegex()
+
+    private suspend fun getProfileAchievements(character: Document) = coroutineScope {
+        val root =
+            character.select(lodestoneCssSelectors.jsonObject["ROOT"] !!.jsonObject["selector"] !!.jsonPrimitive.content)
+                .first() !!
+
+        val achievements = mutableListOf<Achievement>()
+
+        root.select(lodestoneCssSelectors.jsonObject["ENTRY"] !!.jsonObject["ROOT"] !!.jsonObject["selector"] !!.jsonPrimitive.content)
+            .forEach {
+                val name = async {
+                    achievementNameRegex.find(
+                        it.select(getEntrySelector("NAME")).first() !!.text()
+                    ) !!.value
+                }
+
+                val id = async {
+                    achievementIdRegex.find(
+                        it.select(getEntrySelector("ID")).first() !!.attr("href")
+                    ) !!.value.toShort()
+                }
+
+                val date = async {
+                    achievementDateRegex.find(
+                        it.select(getEntrySelector("TIME")).first() !!.html()
+                    ) !!.value.toLong()
+                }
+
+                achievements.add(
+                    Achievement(
+                        name.await(), id.await(), date.await()
+                    )
+                )
+            }
+
+        return@coroutineScope achievements
+    }
+
+    private suspend fun getEntrySelector(entry: String) = coroutineScope {
+        return@coroutineScope lodestoneCssSelectors.jsonObject["ENTRY"] !!.jsonObject[entry] !!.jsonObject["selector"] !!.jsonPrimitive.content
+    }
+
+    private val achievementCountRegex = """\d+""".toRegex()
+
+    private suspend fun getAchievementCount(character: Document, selector: String) =
+        coroutineScope {
+            return@coroutineScope achievementCountRegex.find(
+                character.select(lodestoneCssSelectors.jsonObject[selector] !!.jsonObject["selector"] !!.jsonPrimitive.content)
+                    .first() !!
+                    .text()
+            ) !!.value.toShort()
+        }
+}

--- a/src/main/kotlin/profile/Achievements.kt
+++ b/src/main/kotlin/profile/Achievements.kt
@@ -41,10 +41,6 @@ internal object Achievements {
         )
     }
 
-    private val achievementNameRegex = """"([^"]*)"""".toRegex()
-    private val achievementIdRegex = """\d+(?=\/$)""".toRegex()
-    private val achievementDateRegex = """(?<=ldst_strftime\()\d+""".toRegex()
-
     private suspend fun getProfileAchievements(character: Document, id: Int) =
         coroutineScope {
             val achievements = mutableListOf<Achievement>()
@@ -65,6 +61,10 @@ internal object Achievements {
 
             return@coroutineScope achievements
         }
+
+    private val achievementNameRegex = """"([^"]*)"""".toRegex()
+    private val achievementIdRegex = """\d+(?=\/$)""".toRegex()
+    private val achievementDateRegex = """(?<=ldst_strftime\()\d+""".toRegex()
 
     private suspend fun getPaginatedAchievements(
         page: String,

--- a/src/main/kotlin/profile/Achievements.kt
+++ b/src/main/kotlin/profile/Achievements.kt
@@ -1,7 +1,6 @@
 package cloud.drakon.ktlodestone.profile
 
 import cloud.drakon.ktlodestone.KtLodestone
-import cloud.drakon.ktlodestone.exception.CharacterNotFoundException
 import cloud.drakon.ktlodestone.exception.LodestoneException
 import cloud.drakon.ktlodestone.exception.PagesLessThanOneException
 import cloud.drakon.ktlodestone.profile.achievements.Achievement
@@ -87,18 +86,18 @@ internal object Achievements {
         page: String,
         achievementsList: MutableMap<Short, Achievement>,
     ) = coroutineScope {
+        val character: Document
+
         val request = KtLodestone.ktorClient.get(page) {
             header(
                 HttpHeaders.UserAgent, KtLodestone.userAgentDesktop
             )
         }
 
-        val character: Document
-
-        when (request.status.value) {
-            200 -> character = Jsoup.parse(request.body() as String)
-            404 -> throw CharacterNotFoundException("")
-            else -> throw LodestoneException("The Lodestone returned an unknown error.")
+        if (request.status.value == 200) {
+            character = Jsoup.parse(request.body() as String)
+        } else {
+            throw LodestoneException("The Lodestone returned an unknown error.")
         }
 
         val root =

--- a/src/main/kotlin/profile/Achievements.kt
+++ b/src/main/kotlin/profile/Achievements.kt
@@ -1,13 +1,20 @@
 package cloud.drakon.ktlodestone.profile
 
 import cloud.drakon.ktlodestone.KtLodestone
+import cloud.drakon.ktlodestone.exception.CharacterNotFoundException
+import cloud.drakon.ktlodestone.exception.LodestoneException
 import cloud.drakon.ktlodestone.profile.achievements.Achievement
 import cloud.drakon.ktlodestone.profile.achievements.ProfileAchievements
+import io.ktor.client.call.body
+import io.ktor.client.request.get
+import io.ktor.client.request.header
+import io.ktor.http.HttpHeaders
 import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
+import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
 
 internal object Achievements {
@@ -45,6 +52,40 @@ internal object Achievements {
 
         val achievements = mutableListOf<Achievement>()
 
+        var next =
+            character.select(lodestoneCssSelectors.jsonObject["LIST_NEXT_BUTTON"] !!.jsonObject["selector"] !!.jsonPrimitive.content)
+                .first() !!
+                .attr("href")
+
+        while (next != "javascript:void(0);") {
+            next = getPaginatedAchievements(next, achievements)
+        }
+
+        return@coroutineScope achievements
+    }
+
+    private suspend fun getPaginatedAchievements(
+        page: String,
+        achievementsList: MutableList<Achievement>,
+    ) = coroutineScope {
+        val request = KtLodestone.ktorClient.get(page) {
+            header(
+                HttpHeaders.UserAgent, KtLodestone.userAgentDesktop
+            )
+        }
+
+        val character: Document
+
+        when (request.status.value) {
+            200 -> character = Jsoup.parse(request.body() as String)
+            404 -> throw CharacterNotFoundException("")
+            else -> throw LodestoneException("The Lodestone returned an unknown error.")
+        }
+
+        val root =
+            character.select(lodestoneCssSelectors.jsonObject["ROOT"] !!.jsonObject["selector"] !!.jsonPrimitive.content)
+                .first() !!
+
         root.select(lodestoneCssSelectors.jsonObject["ENTRY"] !!.jsonObject["ROOT"] !!.jsonObject["selector"] !!.jsonPrimitive.content)
             .forEach {
                 val name = async {
@@ -65,14 +106,16 @@ internal object Achievements {
                     ) !!.value.toLong()
                 }
 
-                achievements.add(
+                achievementsList.add(
                     Achievement(
                         name.await(), id.await(), date.await()
                     )
                 )
             }
 
-        return@coroutineScope achievements
+        return@coroutineScope character.select(lodestoneCssSelectors.jsonObject["LIST_NEXT_BUTTON"] !!.jsonObject["selector"] !!.jsonPrimitive.content)
+            .first() !!
+            .attr("href")
     }
 
     private suspend fun getEntrySelector(entry: String) = coroutineScope {

--- a/src/main/kotlin/profile/Achievements.kt
+++ b/src/main/kotlin/profile/Achievements.kt
@@ -1,20 +1,19 @@
 package cloud.drakon.ktlodestone.profile
 
 import cloud.drakon.ktlodestone.KtLodestone
-import cloud.drakon.ktlodestone.exception.LodestoneException
 import cloud.drakon.ktlodestone.exception.PagesLessThanOneException
 import cloud.drakon.ktlodestone.profile.achievements.Achievement
 import cloud.drakon.ktlodestone.profile.achievements.ProfileAchievements
-import io.ktor.client.call.body
-import io.ktor.client.request.get
-import io.ktor.client.request.header
-import io.ktor.http.HttpHeaders
+import kotlin.collections.MutableMap
+import kotlin.collections.forEach
+import kotlin.collections.mutableMapOf
+import kotlin.collections.set
+import kotlin.collections.toMap
 import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
-import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
 
 internal object Achievements {
@@ -86,19 +85,7 @@ internal object Achievements {
         page: String,
         achievementsList: MutableMap<Short, Achievement>,
     ) = coroutineScope {
-        val character: Document
-
-        val request = KtLodestone.ktorClient.get(page) {
-            header(
-                HttpHeaders.UserAgent, KtLodestone.userAgentDesktop
-            )
-        }
-
-        if (request.status.value == 200) {
-            character = Jsoup.parse(request.body() as String)
-        } else {
-            throw LodestoneException("The Lodestone returned an unknown error.")
-        }
+        val character = KtLodestone.getLodestoneProfilePaginated(page)
 
         val root =
             character.select(lodestoneCssSelectors.jsonObject["ROOT"] !!.jsonObject["selector"] !!.jsonPrimitive.content)

--- a/src/main/kotlin/profile/achievements/Achievement.kt
+++ b/src/main/kotlin/profile/achievements/Achievement.kt
@@ -1,0 +1,9 @@
+package cloud.drakon.ktlodestone.profile.achievements
+
+/**
+ * An achievement that a character has acquired.
+ * @property name The name of the achievement.
+ * @property id The ID of the achievement.
+ * @property date The date that the achievement was acquired in Unix time.
+ */
+data class Achievement(val name: String, val id: Short, val date: Long)

--- a/src/main/kotlin/profile/achievements/ProfileAchievements.kt
+++ b/src/main/kotlin/profile/achievements/ProfileAchievements.kt
@@ -1,7 +1,13 @@
 package cloud.drakon.ktlodestone.profile.achievements
 
+/**
+ * The achievements that a character has acquired.
+ * @property achievements A [Map] of achievement ID's to [Achievement].
+ * @property total The amount of achievements that a character has acquired.
+ * @property points The amount of achievement points that a character has acquired.
+ */
 data class ProfileAchievements(
-    val achievements: List<Achievement>,
+    val achievements: Map<Short, Achievement>,
     val total: Short,
     val points: Short,
 )

--- a/src/main/kotlin/profile/achievements/ProfileAchievements.kt
+++ b/src/main/kotlin/profile/achievements/ProfileAchievements.kt
@@ -1,0 +1,7 @@
+package cloud.drakon.ktlodestone.profile.achievements
+
+data class ProfileAchievements(
+    val achievements: List<Achievement>,
+    val total: Short,
+    val points: Short,
+)

--- a/src/test/java/AchievementsAsyncTest.java
+++ b/src/test/java/AchievementsAsyncTest.java
@@ -1,5 +1,6 @@
 import cloud.drakon.ktlodestone.KtLodestone;
 import cloud.drakon.ktlodestone.exception.CharacterNotFoundException;
+import cloud.drakon.ktlodestone.exception.PagesLessThanOneException;
 import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.ExecutionException;
@@ -18,6 +19,17 @@ class AchievementsAsyncTest {
         assertThrows(CharacterNotFoundException.class, () -> {
             try {
                 KtLodestone.getAchievementsAsync(0, (byte) 2).get();
+            } catch (ExecutionException e) {
+                throw e.getCause();
+            }
+        });
+    }
+
+    @Test
+    void getInvalidAchievementsPageAsync() {
+        assertThrows(PagesLessThanOneException.class, () -> {
+            try {
+                KtLodestone.getAchievementsAsync(27545492, (byte) 0).get();
             } catch (ExecutionException e) {
                 throw e.getCause();
             }

--- a/src/test/java/AchievementsAsyncTest.java
+++ b/src/test/java/AchievementsAsyncTest.java
@@ -1,0 +1,26 @@
+import cloud.drakon.ktlodestone.KtLodestone;
+import cloud.drakon.ktlodestone.exception.CharacterNotFoundException;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.ExecutionException;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class AchievementsAsyncTest {
+    @Test
+    void getAchievementsAsync() {
+        assertDoesNotThrow(() -> System.out.println(KtLodestone.getAchievementsAsync(27545492, (byte) 1).get()));
+    }
+
+    @Test
+    void getInvalidAchievementsAsync() {
+        assertThrows(CharacterNotFoundException.class, () -> {
+            try {
+                KtLodestone.getAchievementsAsync(0, (byte) 1).get();
+            } catch (ExecutionException e) {
+                throw e.getCause();
+            }
+        });
+    }
+}

--- a/src/test/java/AchievementsAsyncTest.java
+++ b/src/test/java/AchievementsAsyncTest.java
@@ -10,14 +10,14 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 class AchievementsAsyncTest {
     @Test
     void getAchievementsAsync() {
-        assertDoesNotThrow(() -> System.out.println(KtLodestone.getAchievementsAsync(27545492, (byte) 1).get()));
+        assertDoesNotThrow(() -> System.out.println(KtLodestone.getAchievementsAsync(27545492, (byte) 2).get()));
     }
 
     @Test
     void getInvalidAchievementsAsync() {
         assertThrows(CharacterNotFoundException.class, () -> {
             try {
-                KtLodestone.getAchievementsAsync(0, (byte) 1).get();
+                KtLodestone.getAchievementsAsync(0, (byte) 2).get();
             } catch (ExecutionException e) {
                 throw e.getCause();
             }

--- a/src/test/kotlin/AchievementsTest.kt
+++ b/src/test/kotlin/AchievementsTest.kt
@@ -9,7 +9,7 @@ class AchievementsTest {
     @Test fun getAchievements() {
         Assertions.assertDoesNotThrow {
             return@assertDoesNotThrow runBlocking {
-                println(KtLodestone.getAchievements(27545492))
+                println(KtLodestone.getAchievements(27545492, 1u))
             }
         }
     }
@@ -17,7 +17,7 @@ class AchievementsTest {
     @Test fun getInvalidAchievements() {
         assertThrows<CharacterNotFoundException> {
             return@assertThrows runBlocking {
-                println(KtLodestone.getAchievements(0))
+                println(KtLodestone.getAchievements(0, 1u))
             }
         }
     }

--- a/src/test/kotlin/AchievementsTest.kt
+++ b/src/test/kotlin/AchievementsTest.kt
@@ -9,7 +9,7 @@ class AchievementsTest {
     @Test fun getAchievements() {
         Assertions.assertDoesNotThrow {
             return@assertDoesNotThrow runBlocking {
-                println(KtLodestone.getAchievements(27545492, 1u))
+                println(KtLodestone.getAchievements(27545492, 1))
             }
         }
     }
@@ -17,7 +17,7 @@ class AchievementsTest {
     @Test fun getInvalidAchievements() {
         assertThrows<CharacterNotFoundException> {
             return@assertThrows runBlocking {
-                println(KtLodestone.getAchievements(0, 1u))
+                println(KtLodestone.getAchievements(0, 1))
             }
         }
     }

--- a/src/test/kotlin/AchievementsTest.kt
+++ b/src/test/kotlin/AchievementsTest.kt
@@ -1,5 +1,6 @@
 import cloud.drakon.ktlodestone.KtLodestone
 import cloud.drakon.ktlodestone.exception.CharacterNotFoundException
+import cloud.drakon.ktlodestone.exception.PagesLessThanOneException
 import kotlin.test.Test
 import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.Assertions
@@ -18,6 +19,14 @@ class AchievementsTest {
         assertThrows<CharacterNotFoundException> {
             return@assertThrows runBlocking {
                 println(KtLodestone.getAchievements(0, 2))
+            }
+        }
+    }
+
+    @Test fun getInvalidAchievementsPage() {
+        assertThrows<PagesLessThanOneException> {
+            return@assertThrows runBlocking {
+                println(KtLodestone.getAchievements(27545492, 0))
             }
         }
     }

--- a/src/test/kotlin/AchievementsTest.kt
+++ b/src/test/kotlin/AchievementsTest.kt
@@ -9,7 +9,7 @@ class AchievementsTest {
     @Test fun getAchievements() {
         Assertions.assertDoesNotThrow {
             return@assertDoesNotThrow runBlocking {
-                println(KtLodestone.getAchievements(27545492, 1))
+                println(KtLodestone.getAchievements(27545492, 2))
             }
         }
     }
@@ -17,7 +17,7 @@ class AchievementsTest {
     @Test fun getInvalidAchievements() {
         assertThrows<CharacterNotFoundException> {
             return@assertThrows runBlocking {
-                println(KtLodestone.getAchievements(0, 1))
+                println(KtLodestone.getAchievements(0, 2))
             }
         }
     }

--- a/src/test/kotlin/AchievementsTest.kt
+++ b/src/test/kotlin/AchievementsTest.kt
@@ -1,0 +1,24 @@
+import cloud.drakon.ktlodestone.KtLodestone
+import cloud.drakon.ktlodestone.exception.CharacterNotFoundException
+import kotlin.test.Test
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.assertThrows
+
+class AchievementsTest {
+    @Test fun getAchievements() {
+        Assertions.assertDoesNotThrow {
+            return@assertDoesNotThrow runBlocking {
+                println(KtLodestone.getAchievements(27545492))
+            }
+        }
+    }
+
+    @Test fun getInvalidAchievements() {
+        assertThrows<CharacterNotFoundException> {
+            return@assertThrows runBlocking {
+                println(KtLodestone.getAchievements(0))
+            }
+        }
+    }
+}


### PR DESCRIPTION
- Optionally return a characters achievements
  - `Achievement` contains the following fields:
    - `name`: The name of the achievement
    - `id`: The ID of the achievement
    - `date`: The date that the achievement was acquired in Unix time
  - `ProfileAchievements` contains the following fields:
    - `achievements`: A Map of achievement ID's to `Achievement`
    - `total`: The amount of achievement acquired by a character
    - `points`: The amount of achievement points acquired by a character