### PR TITLE
Move `discipline` to a property of `ActiveClassJob`

### DIFF
--- a/src/main/kotlin/character/ActiveClassJob.kt
+++ b/src/main/kotlin/character/ActiveClassJob.kt
@@ -1,8 +1,13 @@
 package cloud.drakon.ktlodestone.character
 
+import cloud.drakon.ktlodestone.selectors.character.profile.CharacterProfileMaps
+
 /** A Character's active [ClassJob]. */
 data class ActiveClassJob(
     val classJob: ClassJob,
     val level: Byte,
-    val discipline: Discipline,
-)
+) {
+    val discipline = CharacterProfileMaps.DISCIPLINE_MAP.getValue(
+        classJob
+    )
+}

--- a/src/main/kotlin/character/profile/ScrapeCharacterProfile.kt
+++ b/src/main/kotlin/character/profile/ScrapeCharacterProfile.kt
@@ -42,11 +42,7 @@ internal suspend fun scrapeCharacterProfile(response: String) = coroutineScope {
         }
 
         val activeClassJob = async {
-            ActiveClassJob(
-                classJob.await(),
-                level.await(),
-                disciple.await()
-            )
+            ActiveClassJob(classJob.await(), level.await())
         }
 
         val classJobMap = async {

--- a/src/main/kotlin/character/profile/ScrapeCharacterProfile.kt
+++ b/src/main/kotlin/character/profile/ScrapeCharacterProfile.kt
@@ -37,10 +37,6 @@ internal suspend fun scrapeCharacterProfile(response: String) = coroutineScope {
             )!!.value.toByte()
         }
 
-        val disciple = async {
-            CharacterProfileMaps.DISCIPLINE_MAP.getValue(classJob.await())
-        }
-
         val activeClassJob = async {
             ActiveClassJob(classJob.await(), level.await())
         }
@@ -362,13 +358,13 @@ internal suspend fun scrapeCharacterProfile(response: String) = coroutineScope {
             }
 
             val cp = async {
-                if (disciple.await() == Discipline.DISCIPLE_OF_THE_HAND) {
+                if (activeClassJob.await().discipline == Discipline.DISCIPLE_OF_THE_HAND) {
                     this@with.select(AttributesSelectors.CP_GP).text().toShort()
                 } else null
             }
 
             val gp = async {
-                if (disciple.await() == Discipline.DISCIPLE_OF_THE_LAND) {
+                if (activeClassJob.await().discipline == Discipline.DISCIPLE_OF_THE_LAND) {
                     this@with.select(AttributesSelectors.CP_GP).text().toShort()
                 } else null
             }

--- a/src/main/kotlin/character/search/CharacterSearch.kt
+++ b/src/main/kotlin/character/search/CharacterSearch.kt
@@ -198,21 +198,14 @@ internal class CharacterSearch {
 
                             val activeClassJob = it.select(CharacterSearchSelectors.ENTRY_CHARA_INFO)
                                 .let {
-                                    val classJob = CharacterProfileMaps.CLASS_JOB_MAP.getValue(
-                                        it.select(CharacterSearchSelectors.ENTRY_ACTIVE_CLASSJOB)
-                                            .attr(CharacterSearchSelectors.ENTRY_ACTIVE_CLASSJOB_ATTR)
-                                    )
-
-                                    val disciple = CharacterProfileMaps.DISCIPLINE_MAP.getValue(
-                                        classJob
-                                    )
-
                                     ActiveClassJob(
-                                        classJob,
+                                        CharacterProfileMaps.CLASS_JOB_MAP.getValue(
+                                            it.select(CharacterSearchSelectors.ENTRY_ACTIVE_CLASSJOB)
+                                                .attr(CharacterSearchSelectors.ENTRY_ACTIVE_CLASSJOB_ATTR)
+                                        ),
                                         it.select(CharacterSearchSelectors.ENTRY_ACTIVE_CLASSJOB_LEVEL)
                                             .text()
-                                            .toByte(),
-                                        disciple
+                                            .toByte()
                                     )
                                 }
 


### PR DESCRIPTION
Move `discipline` from being part of the constructor of `ActiveClassJob` to a property.